### PR TITLE
Added strokeCap prop

### DIFF
--- a/src/AnimatedCircularProgress.js
+++ b/src/AnimatedCircularProgress.js
@@ -55,4 +55,5 @@ AnimatedCircularProgress.propTypes = {
   width: PropTypes.number.isRequired,
   tintColor: PropTypes.string,
   backgroundColor: PropTypes.string,
+  strokeCap: PropTypes.string
 }

--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -81,6 +81,6 @@ CircularProgress.propTypes = {
 CircularProgress.defaultProps = {
   tintColor: 'black',
   backgroundColor: '#e4e4e4',
-  strokeCap: 'butt'
+  strokeCap: 'butt',
   rotation: 90
 }

--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -30,7 +30,7 @@ export default class CircularProgress extends React.Component {
   }
 
   render() {
-    const { size, width, tintColor, backgroundColor, style, rotation, missingDegree, children } = this.props;
+    const { size, width, tintColor, backgroundColor, style, rotation, missingDegree, children, strokeCap } = this.props;
 
     const circlePath = this.circlePath(size / 2, size / 2, size / 2 - width / 2, missingDegree/2);
     const fill = this.extractFill(this.props.fill);
@@ -39,7 +39,7 @@ export default class CircularProgress extends React.Component {
     if (fill > 0) {
       circle2 = <Shape d={circlePath}
               stroke={tintColor}
-              strokeCap="butt"
+              strokeCap={strokeCap}
               strokeDash={[(size - width) * Math.PI * fill*(1-missingDegree/360) / 100, 700]}
               strokeWidth={width} />;
     }
@@ -52,7 +52,7 @@ export default class CircularProgress extends React.Component {
           <Group rotation={rotation - 90} originX={size/2} originY={size/2}>
             <Shape d={circlePath}
               stroke={backgroundColor}
-              strokeCap="butt"
+              strokeCap={strokeCap}
               strokeDash={[(size - width) * Math.PI*(1-missingDegree/360), 700]}
               strokeWidth={width} />
             {circle2}
@@ -71,6 +71,7 @@ CircularProgress.propTypes = {
   size: PropTypes.number.isRequired,
   fill: PropTypes.number.isRequired,
   width: PropTypes.number.isRequired,
+  strokeCap: Proptypes.string,
   tintColor: PropTypes.string,
   backgroundColor: PropTypes.string,
   rotation: PropTypes.number,
@@ -80,5 +81,6 @@ CircularProgress.propTypes = {
 CircularProgress.defaultProps = {
   tintColor: 'black',
   backgroundColor: '#e4e4e4',
+  strokeCap: 'butt'
   rotation: 90
 }


### PR DESCRIPTION
I found myself working on some graphics which needed exactly the functionality arc-progress had to offer, except the capability to alter the strokeCap on a component level.
With my addition, you'll be able to define the strokeCap behavior on a prop level like so:
```javascript
<CircularProgress
          size={200}
          width={12}
          prefill={0}
          fill={20}
          missingDegree={100}
          strokeCap="circular"
          style = {{marginTop:30}}
          tintColor={colors.accent}
          backgroundColor={colors.base} />
```